### PR TITLE
Fix unicode 11paths authorization

### DIFF
--- a/sdklib/http/authorization.py
+++ b/sdklib/http/authorization.py
@@ -74,9 +74,22 @@ def _sign_data(secret, data):
     return binascii.b2a_base64(sha1_hash.digest())[:-1].decode('utf8')
 
 
+def _local_sha1(data):
+    """
+    Calculate hash and avoid the error "TypeError: Unicode-objects must be encoded before hashing"
+    :param data: the string supporting normal and unicode format
+    :return: hash of the data
+    """
+    try:
+        local_hash = sha1(data).hexdigest()
+    except TypeError:
+        local_hash = sha1(data.encode('utf-8')).hexdigest()
+    return local_hash
+
+
 def _hash_body(context):
     body, _ = context.renderer.encode_params(context.body_params, files=context.files)
-    return sha1(body).hexdigest()
+    return _local_sha1(body)
 
 
 def _hash_file(context):
@@ -85,7 +98,7 @@ def _hash_file(context):
 
     for param in files:
         _, fdata, _, _ = guess_file_name_stream_type_header(files[param])
-        return sha1(fdata).hexdigest()
+        return _local_sha1(fdata)
 
 
 def _get_utc():


### PR DESCRIPTION
Fix this error:
          context.api_response = api.http_request_from_context(context.http_request_context)
        File "d:\entregalo\venv_ruby5\lib\site-packages\sdklib\http\base.py", line 410, in http_request_from_context
          return request_from_context(context)
        File "d:\entregalo\venv_ruby5\lib\site-packages\sdklib\http\base.py", line 60, in request_from_context
          new_context = auth_obj.apply_authentication(new_context)
        File "d:\entregalo\venv_ruby5\lib\site-packages\sdklib\http\authorization.py", line 153, in apply_authentication
          context.headers[X_11PATHS_BODY_HASH_HEADER_NAME] = _hash_body(context)
        File "d:\entregalo\venv_ruby5\lib\site-packages\sdklib\http\authorization.py", line 94, in _hash_body
          return sha1(body).hexdigest()
      TypeError: Unicode-objects must be encoded before hashing

You can see a little explanation of this error and the fix in:
https://stackoverflow.com/questions/27519306/hashlib-md5-typeerror-unicode-objects-must-be-encoded-before-hashing/27519440
https://stackoverflow.com/questions/7585307/how-to-correct-typeerror-unicode-objects-must-be-encoded-before-hashing